### PR TITLE
Applicative and Monad instances for CofreeT

### DIFF
--- a/src/Control/Comonad/Trans/Cofree.hs
+++ b/src/Control/Comonad/Trans/Cofree.hs
@@ -41,6 +41,8 @@ import Data.Foldable
 import Data.Functor.Identity
 import Data.Semigroup
 import Data.Traversable
+import Control.Monad (liftM)
+import Control.Monad.Trans
 import Prelude hiding (id,(.))
 
 #if defined(GHC_TYPEABLE) || __GLASGOW_HASKELL__ >= 707
@@ -145,6 +147,9 @@ instance (Alternative f, Applicative w) => Applicative (CofreeT f w) where
       \(a)      ->
       let (b :< n) = bimap f (fmap f) a in
       b :< (n <|> fmap (<*> aa) t)) <$> wf <*> wa
+
+instance (Alternative f) => MonadTrans (CofreeT f) where
+  lift = CofreeT . liftM (:< empty)
 
 -- | Unfold a @CofreeT@ comonad transformer from a coalgebra and an initial comonad.
 coiterT :: (Functor f, Comonad w) => (w a -> f (w a)) -> w a -> CofreeT f w a


### PR DESCRIPTION
Addresses [issue #22](https://github.com/ekmett/free/issues/22). This preconditions also make `CofreeT f` a monad transformer.

Proofs of the relevant laws (not yet _composition_ for `Applicative`) can be found here:
- [Applicative](https://github.com/team-free/free-doc/blob/master/proofs/cofree-trans-applicative.txt)
- [Monad](https://github.com/team-free/free-doc/blob/master/proofs/cofree-trans-monad.txt)
- [MonadTrans](https://github.com/team-free/free-doc/blob/master/proofs/cofree-trans-monadtrans.txt)

Requiring `Alternative` is perhaps too strong. The proofs and instances are also valid for `Data.Functor.Plus` in the "semigroupoids" package; it's enough to replace `(<|>)` by `(<!>)` and `empty` by `zero`.
