### PR TITLE
Generalized functions from pipes-group

### DIFF
--- a/src/Control/Monad/Free.hs
+++ b/src/Control/Monad/Free.hs
@@ -309,7 +309,7 @@ toFreeT (Free f) = FreeT.FreeT (return (FreeT.Free (fmap toFreeT f)))
 -- Calling 'retract . cutoff n' is always terminating, provided each of the
 -- steps in the iteration is terminating.
 cutoff :: (Functor f) => Integer -> Free f a -> Free f (Maybe a)
-cutoff 0 _ = return Nothing
+cutoff n _ | n <= 0 = return Nothing
 cutoff n (Free f) = Free $ fmap (cutoff (n - 1)) f
 cutoff _ m = Just <$> m
 

--- a/src/Control/Monad/Trans/Free.hs
+++ b/src/Control/Monad/Trans/Free.hs
@@ -40,6 +40,7 @@ module Control.Monad.Trans.Free
   , hoistFreeT
   , transFreeT
   , cutoff
+  , retractT
   -- * Operations of free monad
   , retract
   , iter
@@ -312,6 +313,10 @@ hoistFreeT mh = FreeT . mh . liftM (fmap (hoistFreeT mh)) . runFreeT
 -- | Lift a natural transformation from @f@ to @g@ into a monad homomorphism from @'FreeT' f m@ to @'FreeT' g n@
 transFreeT :: (Monad m, Functor g) => (forall a. f a -> g a) -> FreeT f m b -> FreeT g m b
 transFreeT nt = FreeT . liftM (fmap (transFreeT nt) . transFreeF nt) . runFreeT
+
+-- | Tear down a free monad transformer using Monad instance for @t m@.
+retractT :: (Functor (t m), Monad (t m), MonadTrans t, Monad m) => FreeT (t m) m a -> t m a
+retractT = iterTM join
 
 -- |
 -- 'retract' is the left inverse of 'liftF'

--- a/src/Control/Monad/Trans/Free.hs
+++ b/src/Control/Monad/Trans/Free.hs
@@ -355,7 +355,7 @@ iterM phi = iterT phi . hoistFreeT (return . runIdentity)
 -- Calling @'retract' '.' 'cutoff' n@ is always terminating, provided each of the
 -- steps in the iteration is terminating.
 cutoff :: (Functor f, Monad m) => Integer -> FreeT f m a -> FreeT f m (Maybe a)
-cutoff 0 _ = return Nothing
+cutoff n _ | n <= 0 = return Nothing
 cutoff n (FreeT m) = FreeT $ bimap Just (cutoff (n - 1)) `liftM` m
 
 -- | @partialIterT n phi m@ interprets first @n@ layers of @m@ using @phi@.


### PR DESCRIPTION
Added:
- `partialIterT` generalizes `drops` (`drops n ~ partialIter n discard`)
- `intercalateT` and `intersperseT` generalize `intercalates`;

Also added `cutoff` for `F`.

I would be grateful for suggestions on names and/or implementations before replicating those for `FT` and `IterT`.