### PR TITLE
Fix foldl' strictness for Control.Monad.Free.Church.F

### DIFF
--- a/src/Control/Monad/Free/Church.hs
+++ b/src/Control/Monad/Free/Church.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -118,8 +119,7 @@ instance (Foldable f, Functor f) => Foldable (F f) where
     {-# INLINE foldr #-}
 
 #if MIN_VERSION_base(4,6,0)
-    foldl' f z xs = runF xs (flip f) (foldr (!>>>) id) z
-      where (!>>>) h g = \r -> g $! h r
+    foldl' f z xs = runF xs (\a !r -> f r a) (flip $ foldl' $ \r g -> g r) z
     {-# INLINE foldl' #-}
 #endif
 


### PR DESCRIPTION
The `foldl'` implementation for `F` was still suffering performance-wise because it wasn't strict in the right place, and too strict in another. Also, I think it should use the underlying `Foldable`'s `foldl'`, rather than trying to reinvent it in terms of `foldr`.
