### PR TITLE
Applicative FT is backwards

### DIFF
--- a/src/Control/Monad/Trans/Free/Church.hs
+++ b/src/Control/Monad/Trans/Free/Church.hs
@@ -83,7 +83,7 @@ instance Apply (FT f m) where
 
 instance Applicative (FT f m) where
   pure a = FT $ \k _ -> k a
-  FT fk <*> FT ak = FT $ \b fr -> ak (\d -> fk (\e -> b (e d)) fr) fr
+  FT fk <*> FT ak = FT $ \b fr -> fk (\e -> ak (\d -> b (e d)) fr) fr
 
 instance Bind (FT f m) where
   (>>-) = (>>=)


### PR DESCRIPTION
Can't say I know what I'm doing, but I believe `x *> y *> z` should agree with `x >> y >> z`. Currently their order of effects is opposite
