### PR TITLE
Comment that Alternative, MonadPlus (F f) instances break laws.

### DIFF
--- a/src/Control/Monad/Free/Church.hs
+++ b/src/Control/Monad/Free/Church.hs
@@ -98,6 +98,7 @@ instance Applicative (F f) where
   pure a = F (\kp _ -> kp a)
   F f <*> F g = F (\kp kf -> f (\a -> g (kp . a) kf) kf)
 
+-- | This violates the Alternative laws, handle with care.
 instance Alternative f => Alternative (F f) where
   empty = F (\_ kf -> kf empty)
   F f <|> F g = F (\kp kf -> kf (pure (f kp kf) <|> pure (g kp kf)))
@@ -123,6 +124,7 @@ instance (Foldable f, Functor f) => Foldable (F f) where
     {-# INLINE foldl' #-}
 #endif
 
+-- | This violates the MonadPlus laws, handle with care.
 instance MonadPlus f => MonadPlus (F f) where
   mzero = F (\_ kf -> kf mzero)
   F f `mplus` F g = F (\kp kf -> kf (return (f kp kf) `mplus` return (g kp kf)))


### PR DESCRIPTION
Demonstration of left identity law violation:

```haskell
λ> empty <|> Just 2
Just 2
λ> retract (liftF (Just 2) :: F Maybe Int)
Just 2
λ> retract (empty <|> (liftF (Just 2) :: F Maybe Int))
Nothing
λ> retract (mzero `mplus` (liftF (Just 2) :: F Maybe Int))
Nothing
```