### PR TITLE
Pull out and join m layers of a free transformer structure

### DIFF
--- a/src/Control/Monad/Trans/Free.hs
+++ b/src/Control/Monad/Trans/Free.hs
@@ -39,6 +39,7 @@ module Control.Monad.Trans.Free
   , iterTM
   , hoistFreeT
   , transFreeT
+  , joinFreeT
   , cutoff
   -- * Operations of free monad
   , retract
@@ -312,6 +313,13 @@ hoistFreeT mh = FreeT . mh . liftM (fmap (hoistFreeT mh)) . runFreeT
 -- | Lift a natural transformation from @f@ to @g@ into a monad homomorphism from @'FreeT' f m@ to @'FreeT' g n@
 transFreeT :: (Monad m, Functor g) => (forall a. f a -> g a) -> FreeT f m b -> FreeT g m b
 transFreeT nt = FreeT . liftM (fmap (transFreeT nt) . transFreeF nt) . runFreeT
+
+-- | Pull out and join @m@ layers of @'FreeT' f m a@.
+joinFreeT :: (Monad m, Traversable f) => FreeT f m a -> m (Free f a)
+joinFreeT (FreeT m) = m >>= joinFreeF
+  where
+    joinFreeF (Pure x) = return (return x)
+    joinFreeF (Free f) = wrap `liftM` Data.Traversable.mapM joinFreeT f
 
 -- |
 -- 'retract' is the left inverse of 'liftF'

--- a/src/Control/Monad/Trans/Free/Church.hs
+++ b/src/Control/Monad/Trans/Free/Church.hs
@@ -33,6 +33,7 @@ module Control.Monad.Trans.Free.Church
   , iterTM
   , hoistFT
   , transFT
+  , joinFT
   , cutoff
   -- * Operations of free monad
   , improve
@@ -205,6 +206,10 @@ hoistFT phi (FT m) = FT (\kp kf -> join . phi $ m (return . kp) (return . kf . f
 -- | Lift a natural transformation from @f@ to @g@ into a monad homomorphism from @'FT' f m@ to @'FT' g n@
 transFT :: (Monad m, Functor g) => (forall a. f a -> g a) -> FT f m b -> FT g m b
 transFT phi (FT m) = FT (\kp kf -> m kp (kf . phi))
+
+-- | Pull out and join @m@ layers of @'FreeT' f m a@.
+joinFT :: (Monad m, Traversable f) => FT f m a -> m (F f a)
+joinFT (FT m) = m (return . return) (liftM wrap . T.sequence)
 
 -- | Cuts off a tree of computations at a given depth.
 -- If the depth is 0 or less, no computation nor


### PR DESCRIPTION
`joinFreeT` extracts `Free f a` structure from a `FreeT f m a` computation by pulling out and joining `m` layers.

For free monad transformers `f` should be `Traversable` for this to be possible.
For free applicative transformers `f` can be anything.

The naming is due to the fact that these functions "pull out and **join** `m` layers".
But perhaps there is a better name.

One possible usage of `joinFreeT` is when `f` represents a log entry and `FreeT f m a` — a computation with possibly branching log structure. Therefore with `joinFreeT` we can run computation and extract it's `Free f a` log structure.

I also have another family of functions in mind:

```haskell
execFreeT :: (Monad m, Foldable f) => FreeT f m a -> m ()
execFreeT (FreeT m) = m >>= execFreeF
  where
    execFreeF (Pure x) = return ()
    execFreeF (Free f) = F.mapM_ execFreeT f
```

`execFreeT` is effectively `void . joinFreeT` with a weaker constraint on `f`. Although it seems reasonable to introduce `execFreeT` along `joinFreeT`, I do not actually have a use case in mind for the former.