### PR TITLE
Add a performance-optimized version of length for Cofree

### DIFF
--- a/src/Control/Comonad/Cofree.hs
+++ b/src/Control/Comonad/Cofree.hs
@@ -192,6 +192,8 @@ instance Foldable f => Foldable (Cofree f) where
   foldMap f = go where
     go (a :< as) = f a `mappend` foldMap go as
   {-# INLINE foldMap #-}
+  length = go 0 where
+    go s (_ :< as) = foldl' go (s + 1) as
 
 instance Foldable1 f => Foldable1 (Cofree f) where
   foldMap1 f = go where

--- a/src/Control/Comonad/Cofree.hs
+++ b/src/Control/Comonad/Cofree.hs
@@ -192,8 +192,10 @@ instance Foldable f => Foldable (Cofree f) where
   foldMap f = go where
     go (a :< as) = f a `mappend` foldMap go as
   {-# INLINE foldMap #-}
+#if __GLASGOW_HASKELL__ >= 709
   length = go 0 where
     go s (_ :< as) = foldl' go (s + 1) as
+#endif
 
 instance Foldable1 f => Foldable1 (Cofree f) where
   foldMap1 f = go where


### PR DESCRIPTION
```
import Criterion.Main

import Control.Comonad.Cofree
import Data.Foldable


sizeF :: Foldable f => Cofree f a -> Int
sizeF = go 0
  where
    go s (_ :< xs) = foldl' go (s + 1) xs


tree :: Cofree [] Int
tree = coiter (\i -> [1 .. i - 1]) 11

list :: Cofree Maybe Int
list = coiter (\i -> if i == 1 then Nothing else Just (i - 1)) 1000


main :: IO ()
main = defaultMain [ bgroup "tree" [ bench "length" $ whnf length tree
                                   , bench "sizeF"  $ whnf sizeF tree
                                   ]
                   , bgroup "list" [ bench "length" $ whnf length list
                                   , bench "sizeF"  $ whnf sizeF list
                                   ]
                   ]
```

With results like:

```
$ ./benchcofree 
benchmarking tree/length
time                 166.1 μs   (160.5 μs .. 171.4 μs)
                     0.992 R²   (0.988 R² .. 0.995 R²)
mean                 165.2 μs   (161.5 μs .. 170.0 μs)
std dev              13.19 μs   (11.34 μs .. 15.91 μs)
variance introduced by outliers: 72% (severely inflated)

benchmarking tree/sizeF
time                 9.779 μs   (9.392 μs .. 10.13 μs)
                     0.992 R²   (0.987 R² .. 0.996 R²)
mean                 9.622 μs   (9.363 μs .. 9.885 μs)
std dev              873.6 ns   (726.4 ns .. 1.074 μs)
variance introduced by outliers: 84% (severely inflated)

benchmarking list/length
time                 129.7 μs   (125.7 μs .. 133.0 μs)
                     0.993 R²   (0.990 R² .. 0.996 R²)
mean                 128.0 μs   (124.5 μs .. 131.9 μs)
std dev              13.23 μs   (10.16 μs .. 17.42 μs)
variance introduced by outliers: 82% (severely inflated)

benchmarking list/sizeF
time                 6.326 μs   (6.132 μs .. 6.527 μs)
                     0.992 R²   (0.988 R² .. 0.994 R²)
mean                 6.370 μs   (6.145 μs .. 6.613 μs)
std dev              822.7 ns   (655.0 ns .. 1.026 μs)
variance introduced by outliers: 92% (severely inflated)
```

This looks like a pretty big performance win.  I don't *think* it's sacrificing any good properties to get it, either.  I'm sure there are related improvements possible, but this is the one I already wrote code for.