### PR TITLE
Free applicative: better application order

### DIFF
--- a/src/Control/Applicative/Free.hs
+++ b/src/Control/Applicative/Free.hs
@@ -52,7 +52,7 @@ import Data.Monoid
 -- | The free 'Applicative' for a 'Functor' @f@.
 data Ap f a where
   Pure :: a -> Ap f a
-  Ap   :: f a -> Ap f (a -> b) -> Ap f b
+  Ap   :: Ap f (a -> b) -> f a -> Ap f b
 #if __GLASGOW_HASKELL__ >= 707
   deriving Typeable
 #endif
@@ -62,7 +62,7 @@ data Ap f a where
 -- prop> runAp t == retractApp . hoistApp t
 runAp :: Applicative g => (forall x. f x -> g x) -> Ap f a -> g a
 runAp _ (Pure x) = pure x
-runAp u (Ap f x) = flip id <$> u f <*> runAp u x
+runAp u (Ap f x) = flip id <$> u x <*> runAp u f
 
 -- | Perform a monoidal analysis over free applicative value.
 --
@@ -77,26 +77,26 @@ runAp_ f = getConst . runAp (Const . f)
 
 instance Functor (Ap f) where
   fmap f (Pure a)   = Pure (f a)
-  fmap f (Ap x y)   = Ap x ((f .) <$> y)
+  fmap f (Ap g x)   = Ap ((f .) <$> g) x
 
 instance Apply (Ap f) where
   Pure f <.> y = fmap f y
-  Ap x y <.> z = Ap x (flip <$> y <.> z)
+  Ap f x <.> y = Ap (flip <$> f <.> y) x
 
 instance Applicative (Ap f) where
   pure = Pure
   Pure f <*> y = fmap f y
-  Ap x y <*> z = Ap x (flip <$> y <*> z)
+  Ap f x <*> y = Ap (flip <$> f <.> y) x
 
 -- | A version of 'lift' that can be used with just a 'Functor' for @f@.
 liftAp :: f a -> Ap f a
-liftAp x = Ap x (Pure id)
+liftAp x = Ap (Pure id) x
 {-# INLINE liftAp #-}
 
 -- | Given a natural transformation from @f@ to @g@ this gives a monoidal natural transformation from @Ap f@ to @Ap g@.
 hoistAp :: (forall a. f a -> g a) -> Ap f b -> Ap g b
 hoistAp _ (Pure a) = Pure a
-hoistAp f (Ap x y) = Ap (f x) (hoistAp f y)
+hoistAp f (Ap g x) = Ap (hoistAp f g) (f x)
 
 -- | Interprets the free applicative functor over f using the semantics for
 --   `pure` and `<*>` given by the Applicative instance for f.
@@ -104,7 +104,7 @@ hoistAp f (Ap x y) = Ap (f x) (hoistAp f y)
 --   prop> retractApp == runAp id
 retractAp :: Applicative f => Ap f a -> f a
 retractAp (Pure a) = pure a
-retractAp (Ap x y) = x <**> retractAp y
+retractAp (Ap f x) = x <**> retractAp f
 
 #if __GLASGOW_HASKELL__ < 707
 instance Typeable1 f => Typeable1 (Ap f) where


### PR DESCRIPTION
After reading and understanding about free applicative for the first time, this somehow made a lot of sense to me. Feel free to tell me if it doesn't :)

This change makes the construction as the order of the standard function application rather than the inverse. Also, making the code a bit shorter and with better letters picked for parameters, a bit more readable.

Does anyone outside of Control/Applicative/Free.hs depend on the order of things to Ap? I see it is exported, though the build of 'free' passes.
