### PR TITLE
Now with `ExceptT`.

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+4.12.2
+------
+* Add instances for `ExceptT`: like `ErrorT`, but without an `Error` constraint.
+
 4.12.1
 ------
 * Support GHC 7.4

--- a/free.cabal
+++ b/free.cabal
@@ -77,6 +77,7 @@ library
     semigroupoids        >= 4 && < 6,
     semigroups           >= 0.8.3.1 && < 1,
     transformers         >= 0.2.0   && < 0.5,
+    transformers-compat  >= 0.3     && < 1,
     template-haskell     >= 2.7.0.0 && < 3,
     exceptions           >= 0.6 && < 0.9,
     containers           < 0.6

--- a/free.cabal
+++ b/free.cabal
@@ -1,6 +1,6 @@
 name:          free
 category:      Control, Monads
-version:       4.12.1
+version:       4.12.2
 license:       BSD3
 cabal-version: >= 1.10
 license-file:  LICENSE

--- a/src/Control/Monad/Free/Class.hs
+++ b/src/Control/Monad/Free/Class.hs
@@ -43,6 +43,7 @@ import Control.Monad.Trans.Cont
 import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.List
 import Control.Monad.Trans.Error
+import Control.Monad.Trans.Except
 import Control.Monad.Trans.Identity
 
 #if !(MIN_VERSION_base(4,8,0))
@@ -143,6 +144,9 @@ instance (Functor f, MonadFree f m) => MonadFree f (ListT m) where
 
 instance (Functor f, MonadFree f m, Error e) => MonadFree f (ErrorT e m) where
   wrap = ErrorT . wrap . fmap runErrorT
+
+instance (Functor f, MonadFree f m) => MonadFree f (ExceptT e m) where
+  wrap = ExceptT . wrap . fmap runExceptT
 
 -- instance (Functor f, MonadFree f m) => MonadFree f (EitherT e m) where
 --   wrap = EitherT . wrap . fmap runEitherT


### PR DESCRIPTION
As the change log indicates, I added instances for `ExceptT`.
They work like `ErrorT`, but without an `Error` constraint.
Now one can easily work with transformer stacks like
`Monad m => ExceptT Problem (StateT World (FreeT Effect m)) ()`.

I also bumped the version number since
changes to this library are not very frequent.