### PR TITLE
make `free` forward`-Wcompat`ible (again)

### DIFF
--- a/free.cabal
+++ b/free.cabal
@@ -110,3 +110,9 @@ library
     Data.Functor.Classes.Compat
 
   ghc-options: -Wall
+
+  -- See https://ghc.haskell.org/trac/ghc/wiki/Migration/8.0#base-4.9.0.0
+  if impl(ghc >= 8.0)
+    ghc-options: -Wcompat -Wnoncanonical-monad-instances -Wnoncanonical-monadfail-instances
+  else
+    build-depends: fail == 4.9.*

--- a/src/Control/Alternative/Free.hs
+++ b/src/Control/Alternative/Free.hs
@@ -119,7 +119,7 @@ instance Semigroup (Alt f a) where
 instance Monoid (Alt f a) where
   mempty = empty
   {-# INLINE mempty #-}
-  mappend = (<|>)
+  mappend = (<>)
   {-# INLINE mappend #-}
   mconcat as = Alt (as >>= alternatives)
   {-# INLINE mconcat #-}

--- a/src/Control/Alternative/Free/Final.hs
+++ b/src/Control/Alternative/Free/Final.hs
@@ -50,7 +50,7 @@ instance Semigroup (Alt f a) where
 
 instance Monoid (Alt f a) where
   mempty = empty
-  mappend = (<|>)
+  mappend = (<>)
 
 -- | A version of 'lift' that can be used with @f@.
 liftAlt :: f a -> Alt f a

--- a/src/Control/Monad/Trans/Free.hs
+++ b/src/Control/Monad/Trans/Free.hs
@@ -57,6 +57,7 @@ import Control.Monad.Base (MonadBase(..))
 import Control.Monad.Catch (MonadThrow(..), MonadCatch(..))
 import Control.Monad.Trans.Class
 import Control.Monad.Free.Class
+import qualified Control.Monad.Fail as Fail
 import Control.Monad.IO.Class
 import Control.Monad.Reader.Class
 import Control.Monad.Writer.Class
@@ -297,12 +298,16 @@ instance (Functor f, Monad m) => Bind (FreeT f m) where
   (>>-) = (>>=)
 
 instance (Functor f, Monad m) => Monad (FreeT f m) where
-  fail e = FreeT (fail e)
   return = pure
   {-# INLINE return #-}
   FreeT m >>= f = FreeT $ m >>= \v -> case v of
     Pure a -> runFreeT (f a)
     Free w -> return (Free (fmap (>>= f) w))
+
+  fail = Fail.fail
+
+instance (Functor f, Monad m) => Fail.MonadFail (FreeT f m) where
+  fail e = FreeT (fail e)
 
 instance MonadTrans (FreeT f) where
   lift = FreeT . liftM Pure

--- a/src/Control/Monad/Trans/Free/Ap.hs
+++ b/src/Control/Monad/Trans/Free/Ap.hs
@@ -46,6 +46,7 @@ import Control.Applicative
 import Control.Monad (liftM, MonadPlus(..), join)
 import Control.Monad.Catch (MonadThrow(..), MonadCatch(..))
 import Control.Monad.Trans.Class
+import qualified Control.Monad.Fail as Fail
 import Control.Monad.Free.Class
 import Control.Monad.IO.Class
 import Control.Monad.Reader.Class
@@ -297,12 +298,15 @@ instance (Apply f, Apply m, Monad m) => Bind (FreeT f m) where
     Free w -> return (Free (fmap (>>- f) w))
 
 instance (Applicative f, Applicative m, Monad m) => Monad (FreeT f m) where
-  fail e = FreeT (fail e)
   return = pure
   {-# INLINE return #-}
   FreeT m >>= f = FreeT $ m >>= \v -> case v of
     Pure a -> runFreeT (f a)
     Free w -> return (Free (fmap (>>= f) w))
+  fail = Fail.fail
+
+instance (Applicative f, Applicative m, Monad m) => Fail.MonadFail (FreeT f m) where
+  fail e = FreeT (fail e)
 
 instance MonadTrans (FreeT f) where
   lift = FreeT . liftM Pure


### PR DESCRIPTION
This is a follow-up to c9430031460a7c89038dc5e24796b69f3568b61e
but this time we have warning flags we can put in place to get
alerted of regressions.

This represents a breaking change as it changes the class constraints
for some `Monoid` instances.

Note: the constraints on some `MonadFail` could possibly be relaxed