### PR TITLE
Add a Comonad instance to Control.Applicative.Free

### DIFF
--- a/src/Control/Applicative/Free.hs
+++ b/src/Control/Applicative/Free.hs
@@ -41,6 +41,7 @@ module Control.Applicative.Free
   ) where
 
 import Control.Applicative
+import Control.Comonad (Comonad(..))
 import Data.Functor.Apply
 import Data.Typeable
 
@@ -87,6 +88,12 @@ instance Applicative (Ap f) where
   Pure f <*> y = fmap f y
   Ap x y <*> z = Ap x (flip <$> y <*> z)
 
+instance Comonad f => Comonad (Ap f) where
+  extract (Pure a) = a
+  extract (Ap x y) = extract y (extract x)
+  duplicate (Pure a) = Pure (Pure a)
+  duplicate (Ap x y) = Ap (duplicate x) (extend (flip Ap) y)
+  
 -- | A version of 'lift' that can be used with just a 'Functor' for @f@.
 liftAp :: f a -> Ap f a
 liftAp x = Ap x (Pure id)


### PR DESCRIPTION
`Free f` can be built out of `f`, `Day`, `Identity` and `Coproduct`, so I think `Free f` should be a `Comonad` whenever `f` itself is.

It's unfortunately not a `ComonadTrans`, since you can't `lower` in the `Pure` case (although the free `Apply` is). I wrote a bit more about this [here](https://gist.github.com/paf31/0bb290665b5890e989afca9fe88368d8).