### PR TITLE
Fix GHC-7.8 transformers installed

### DIFF
--- a/free.cabal
+++ b/free.cabal
@@ -79,7 +79,7 @@ library
     profunctors          >= 4 && < 6,
     semigroupoids        >= 4 && < 6,
     transformers         >= 0.2.0   && < 0.6,
-    transformers-base    < 0.5,
+    transformers-base    >= 0.4 && < 0.5,
     template-haskell     >= 2.7.0.0 && < 3,
     exceptions           >= 0.6 && < 0.11,
     containers           < 0.6

--- a/free.cabal
+++ b/free.cabal
@@ -90,6 +90,12 @@ library
   if !impl(ghc >= 8.0)
     build-depends: semigroups >= 0.8.3.1 && < 1
 
+  -- Ensure Data.Functor.Classes is always available
+  if impl(ghc >= 7.10)
+    build-depends: transformers >= 0.4.2.0
+  else
+    build-depends: transformers-compat >= 0.5.1.0 && <0.7
+
   exposed-modules:
     Control.Applicative.Free
     Control.Applicative.Free.Fast

--- a/include/free-common.h
+++ b/include/free-common.h
@@ -6,6 +6,10 @@
 #define MIN_VERSION_mtl(x,y,z) 1
 #endif
 
+#ifndef MIN_VERSION_transformers_compat
+#define MIN_VERSION_transformers_compat(x,y,z) 0
+#endif
+
 #if MIN_VERSION_base(4,9,0)
 #define LIFTED_FUNCTOR_CLASSES 1
 #else


### PR DESCRIPTION
I think that using `--no-installed` was an oversight. The idea for that feature is to:
- verify that there **is** such install plan (without upgrading boot libs)
- check it

@RyanGlScott if the travis build time is really precious, I can make a flag to `haskell-ci` so installed constraints are added to `cabal.project` used on Travis, i.e.

```
constraints:
  base installed,
  transformers installed,
  containers installed,
  -- and so on
```
