### PR TITLE
Add MonadFail constraints to examples

### DIFF
--- a/examples/PerfTH.hs
+++ b/examples/PerfTH.hs
@@ -12,6 +12,7 @@ import Data.IORef
 import Data.Word
 import Control.Monad
 import Control.Monad.State.Strict
+import Control.Monad.Fail (MonadFail)
 import Control.Monad.Free
 import Control.Monad.Free.TH
 import qualified Control.Monad.Free.Church as Church
@@ -65,7 +66,7 @@ runPerfFree (s:ss) x = case x of
     return a
 
 -- | Church-based interpreter
-runPerfF :: (MonadIO m) => [String] -> Church.F PerfF () -> m ()
+runPerfF :: (MonadFail m, MonadIO m) => [String] -> Church.F PerfF () -> m ()
 runPerfF [] _ = return ()
 runPerfF ss0 f =
   fst `liftM` do

--- a/examples/RetryTH.hs
+++ b/examples/RetryTH.hs
@@ -5,6 +5,7 @@
 module Main where
 
 import Control.Monad
+import Control.Monad.Fail (MonadFail)
 import Control.Monad.Free
 import Control.Monad.Free.TH
 import Control.Monad.IO.Class
@@ -53,10 +54,10 @@ withRetry :: MonadFree RetryF m =>
 -- retry      :: MonadFree RetryF m => m a
 
 -- | We can run a retriable program in any MonadIO.
-runRetry :: MonadIO m => Retry a -> m a
+runRetry :: (MonadFail m, MonadIO m) => Retry a -> m a
 runRetry = iterM run
   where
-    run :: MonadIO m => RetryF (m a) -> m a
+    run :: (MonadFail m, MonadIO m) => RetryF (m a) -> m a
 
     run (Output s next) = do
       liftIO $ putStrLn s

--- a/examples/free-examples.cabal
+++ b/examples/free-examples.cabal
@@ -83,7 +83,7 @@ executable free-retry-th
   hs-source-dirs: .
   default-language: Haskell2010
   main-is: RetryTH.hs
-  ghc-options: -Wall
+  ghc-options: -Wall -fno-warn-orphans
   build-depends:
     base         == 4.*,
     base-compat,

--- a/examples/free-examples.cabal
+++ b/examples/free-examples.cabal
@@ -73,6 +73,7 @@ executable free-perf-th
   build-depends:
     base         == 4.*,
     base-compat,
+    fail         == 4.9.*,
     free,
     mtl          >= 2.0.1 && < 2.3,
     rdtsc,
@@ -86,6 +87,7 @@ executable free-retry-th
   build-depends:
     base         == 4.*,
     base-compat,
+    fail         == 4.9.*,
     free,
     transformers >= 0.2 && < 0.6
 


### PR DESCRIPTION
The `PerfTH` and `RetryTH` examples were failing to build on GHC 8.6 because it enables `MonadFailDesugaring` by default, and there were no `MonadFail` constraints to support the partial pattern matches being used in these examples.

Addresses one bullet point of ekmett/lens#815.