### PR TITLE
Remove Monad constraint on base MonadFree instance

### DIFF
--- a/src/Control/Monad/Trans/Free/Ap.hs
+++ b/src/Control/Monad/Trans/Free/Ap.hs
@@ -373,8 +373,8 @@ instance (Applicative f, Applicative m, MonadPlus m) => MonadPlus (FreeT f m) wh
   mplus (FreeT ma) (FreeT mb) = FreeT (mplus ma mb)
   {-# INLINE mplus #-}
 
-instance (Applicative f, Applicative m, Monad m) => MonadFree f (FreeT f m) where
-  wrap = FreeT . return . Free
+instance (Applicative f, Applicative m) => MonadFree f (FreeT f m) where
+  wrap = FreeT . pure . Free
   {-# INLINE wrap #-}
 
 instance (Applicative f, Applicative m, MonadThrow m) => MonadThrow (FreeT f m) where


### PR DESCRIPTION
Didn't test, let's see what CI says.

A reason not to do this is people who say "MonadFree" in their constraints and expect not to have to say "Monad".

A reason to do this is that http://hackage.haskell.org/package/yoctoparsec-0.1.0.0/docs/src/Control-Monad-Yoctoparsec.html#token could say "token = wrap pure" rather than "token = FreeT . pure . Free $ pure".