### PR TITLE
Remove unnecessary Monad constraints in FreeT instances

### DIFF
--- a/src/Control/Monad/Trans/Free.hs
+++ b/src/Control/Monad/Trans/Free.hs
@@ -284,8 +284,8 @@ instance (Functor f, Read1 f, Functor m, Read1 m, Read a) => Read (FreeT f m a) 
 #endif
   readsPrec = readsPrec1
 
-instance (Functor f, Monad m) => Functor (FreeT f m) where
-  fmap f (FreeT m) = FreeT (liftM f' m) where
+instance (Functor f, Functor m) => Functor (FreeT f m) where
+  fmap f (FreeT m) = FreeT (fmap f' m) where
     f' (Pure a)  = Pure (f a)
     f' (Free as) = Free (fmap (fmap f) as)
 


### PR DESCRIPTION
The `Monad m` constraints in `Functor FreeT` and `Applicative FreeT` instances are too restrictive and can be loosened to `Functor` and `Applicative` constraints respectively.