### PR TITLE
Loosen constraints on Functor, Applicative, Apply, Traversable

### DIFF
--- a/src/Control/Monad/Trans/Free.hs
+++ b/src/Control/Monad/Trans/Free.hs
@@ -433,8 +433,8 @@ foldFreeT f (FreeT m) = lift m >>= foldFreeF
     foldFreeF (Free as) = f as >>= foldFreeT f
 
 -- | Lift a natural transformation from @f@ to @g@ into a monad homomorphism from @'FreeT' f m@ to @'FreeT' g m@
-transFreeT :: (Monad m, Functor g) => (forall a. f a -> g a) -> FreeT f m b -> FreeT g m b
-transFreeT nt = FreeT . liftM (fmap (transFreeT nt) . transFreeF nt) . runFreeT
+transFreeT :: (Functor m, Functor g) => (forall a. f a -> g a) -> FreeT f m b -> FreeT g m b
+transFreeT nt = FreeT . fmap (fmap (transFreeT nt) . transFreeF nt) . runFreeT
 
 -- | Pull out and join @m@ layers of @'FreeT' f m a@.
 joinFreeT :: (Monad m, Traversable f) => FreeT f m a -> m (Free f a)
@@ -478,9 +478,9 @@ iterM phi = iterT phi . hoistFreeT (return . runIdentity)
 --
 -- Calling @'retract' '.' 'cutoff' n@ is always terminating, provided each of the
 -- steps in the iteration is terminating.
-cutoff :: (Functor f, Monad m) => Integer -> FreeT f m a -> FreeT f m (Maybe a)
-cutoff n _ | n <= 0 = return Nothing
-cutoff n (FreeT m) = FreeT $ bimap Just (cutoff (n - 1)) `liftM` m
+cutoff :: (Functor f, Applicative m) => Integer -> FreeT f m a -> FreeT f m (Maybe a)
+cutoff n _ | n <= 0 = pure Nothing
+cutoff n (FreeT m) = FreeT $ bimap Just (cutoff (n - 1)) <$> m
 
 -- | @partialIterT n phi m@ interprets first @n@ layers of @m@ using @phi@.
 -- This is sort of the opposite for @'cutoff'@.

--- a/src/Control/Monad/Trans/Free/Ap.hs
+++ b/src/Control/Monad/Trans/Free/Ap.hs
@@ -312,7 +312,7 @@ instance (Applicative f, Applicative m, Monad m) => Monad (FreeT f m) where
 instance (Applicative f, Applicative m, Monad m) => Fail.MonadFail (FreeT f m) where
   fail e = FreeT (fail e)
 
-instance Functor f => MonadTrans (FreeT f) where
+instance MonadTrans (FreeT f) where
   lift = FreeT . liftM Pure
   {-# INLINE lift #-}
 

--- a/src/Control/Monad/Trans/Iter.hs
+++ b/src/Control/Monad/Trans/Iter.hs
@@ -204,8 +204,8 @@ instance (Functor m, Read1 m, Read a) => Read (IterT m a) where
 #endif
   readsPrec = readsPrec1
 
-instance Monad m => Functor (IterT m) where
-  fmap f = IterT . liftM (bimap f (fmap f)) . runIterT
+instance Functor m => Functor (IterT m) where
+  fmap f = IterT . fmap (bimap f (fmap f)) . runIterT
   {-# INLINE fmap #-}
 
 instance Monad m => Applicative (IterT m) where


### PR DESCRIPTION
This is basically a duplicate of #154. I think that this is a good proposal.

I worked out the details of `Applicative m => Applicative (FreeT f m)` and it should be equivalent to `ap`.

I also aim to loosen other `Monad` constraints where possible.