### PR TITLE
Use deforestation to simplify Core related to iter

### DIFF
--- a/src/Control/Monad/Free.hs
+++ b/src/Control/Monad/Free.hs
@@ -39,7 +39,6 @@ module Control.Monad.Free
   ) where
 
 import Control.Applicative
-import Control.Arrow ((>>>))
 import Control.Monad (liftM, MonadPlus(..), (>=>))
 import Control.Monad.Fix
 import Control.Monad.Trans.Class
@@ -340,10 +339,23 @@ retract :: Monad f => Free f a -> f a
 retract (Pure a) = return a
 retract (Free as) = as >>= retract
 
+type FCata f a = (forall r. (f r -> r) -> (a -> r) -> r)
+
+buildF :: FCata f a -> Free f a
+buildF f = f Free Pure
+
+{-# INLINE [1] buildF #-}
+
 -- | Tear down a 'Free' 'Monad' using iteration.
 iter :: Functor f => (f a -> a) -> Free f a -> a
 iter _ (Pure a) = a
 iter phi (Free m) = phi (iter phi <$> m)
+
+{-# INLINE [0] iter #-}
+
+{-# RULES "iter/buildF" [~1]
+     forall (phi :: f a -> a) (g :: FCata f a).
+       iter phi (buildF g) = g phi id #-}
 
 -- | Like 'iter' for applicative values.
 iterA :: (Applicative p, Functor f) => (f (p a) -> p a) -> Free f a -> p a
@@ -385,13 +397,21 @@ toFreeT (Free f) = FreeT.FreeT (return (FreeT.Free (fmap toFreeT f)))
 -- Calling 'retract . cutoff n' is always terminating, provided each of the
 -- steps in the iteration is terminating.
 cutoff :: (Functor f) => Integer -> Free f a -> Free f (Maybe a)
-cutoff n _ | n <= 0 = return Nothing
-cutoff n (Free f) = Free $ fmap (cutoff (n - 1)) f
-cutoff _ m = Just <$> m
+cutoff n b = buildF $ \u p ->
+  let c n' x
+          | n <= 0 = p Nothing
+          | otherwise = case x of
+                Pure v -> p (Just v)
+                Free f -> u (fmap (c (n' - 1)) f)
+  in c n b
 
 -- | Unfold a free monad from a seed.
 unfold :: Functor f => (b -> Either a (f b)) -> b -> Free f a
-unfold f = f >>> either Pure (Free . fmap (unfold f))
+unfold f b = buildF $ \u p ->
+  let c x = case f x of
+          Left  a -> p a
+          Right g -> u (fmap c g)
+  in c b
 
 -- | Unfold a free monad from a seed, monadically.
 unfoldM :: (Traversable f, Applicative m, Monad m) => (b -> m (Either a (f b))) -> b -> m (Free f a)


### PR DESCRIPTION
Consider this example code:

```haskell
example :: Int -> Float
example x = iter phi (unfold psi x)
  where
  psi :: Int -> Either Float (Int, Int)
  psi n = if even n then Left 2.5 else Right (5, n)

  phi :: (Int, Float) -> Float
  phi (x', y') = fromIntegral x' * y'

```

With deforestation. Note the absence of tuples or Either.

```
Rec {
$wc :: Int# -> Float#
$wc
  = \ (ww :: Int#) ->
      case remInt# ww 2# of {
        __DEFAULT ->
          case $wc ww of ww1 { __DEFAULT -> timesFloat# 5.0# ww1 };
        0# -> 2.5#
      }
end Rec }

example_c :: Int -> Float
example_c
  = \ (w :: Int) ->
      case w of { I# ww1 -> case $wc ww1 of ww2 { __DEFAULT -> F# ww2 } }

example :: Int -> Float
example = example_c
```

Without deforestation:

```
example5 :: (Int, Float) -> Float
example5
  = \ (ds :: (Int, Float)) ->
      case ds of { (x, y) ->
      case x of { I# i ->
      case y of { F# y1 -> F# (timesFloat# (int2Float# i) y1) }
      }
      }

example4 :: Int
example4 = I# 5#

example3 :: Float
example3 = F# 2.5#

example2 :: Either Float (Int, Int)
example2 = Left example3

example1 :: Int -> Either Float (Int, Int)
example1
  = \ (n :: Int) ->
      case n of wild2 { I# x1 ->
      case remInt# x1 2# of {
        __DEFAULT -> Right (example4, wild2);
        0# -> example2
      }
      }

example :: Int -> Float
example
  = \ (x :: Int) ->
      example_$siter example5 (example_$sunfold example1 x)
```

One thing to note is that for this to happen, you must use the new `buildF` function to build up your `Free` structures, and then ensure that this function is inlined so that GHC can see the occurrence of `iter f (buildF g)`.