### PR TITLE
add some, many to Alternative instance for final Alt encoding

### DIFF
--- a/src/Control/Alternative/Free/Final.hs
+++ b/src/Control/Alternative/Free/Final.hs
@@ -48,6 +48,8 @@ instance Alt.Alt (Alt f) where
 instance Alternative (Alt f) where
   empty = Alt (\_ -> empty)
   Alt x <|> Alt y = Alt (\k -> x k <|> y k)
+  some (Alt x) = Alt $ \k -> some (x k)
+  many (Alt x) = Alt $ \k -> many (x k)
 
 instance Semigroup (Alt f a) where
   (<>) = (<|>)


### PR DESCRIPTION
This will allow `runAlt` to take advantage of more performant `some` and `many` in the target concrete `Alternative`.

Thanks for the great package by the way :)