### PR TITLE
Free Apply, Alt, and Plus

### DIFF
--- a/free.cabal
+++ b/free.cabal
@@ -124,6 +124,9 @@ library
     Control.Monad.Trans.Free.Ap
     Control.Monad.Trans.Free.Church
     Control.Monad.Trans.Iter
+    Data.Functor.Alt.Free
+    Data.Functor.Apply.Free
+    Data.Functor.Plus.Free
 
   other-modules:
     Data.Functor.Classes.Compat

--- a/src/Data/Functor/Alt/Free.hs
+++ b/src/Data/Functor/Alt/Free.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE DeriveFoldable    #-}
+{-# LANGUAGE DeriveFunctor     #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE RankNTypes        #-}
+
+module Data.Functor.Alt.Free (
+    NonEmptyF(..)
+  , runNonEmptyF
+  , liftNonEmptyF
+  , hoistNonEmptyF
+  , toListF
+  ) where
+
+import           Data.Functor.Alt
+import           Data.Functor.Plus.Free
+import           Data.List.NonEmpty         (NonEmpty(..))
+import           Data.Semigroup.Foldable
+import           Data.Semigroup.Traversable
+import qualified Data.List.NonEmpty         as NE
+
+-- | The free 'Alt'
+newtype NonEmptyF f a = NonEmptyF { alts :: NonEmpty (f a) }
+  deriving (Functor, Foldable, Traversable)
+
+instance Functor f => Alt (NonEmptyF f) where
+    NonEmptyF xs <!> NonEmptyF ys = NonEmptyF (xs <> ys)
+
+instance Semigroup (NonEmptyF f a) where
+    NonEmptyF xs <> NonEmptyF ys = NonEmptyF (xs <> ys)
+
+instance Foldable1 f => Foldable1 (NonEmptyF f) where
+    foldMap1 f (NonEmptyF ys) = (foldMap1 . foldMap1) f ys
+
+instance Traversable1 f => Traversable1 (NonEmptyF f) where
+    traverse1 f (NonEmptyF ys) = NonEmptyF <$> (traverse1 . traverse1) f ys
+
+-- | Given a natural transformation from @f@ to @g@, this gives a canonical
+-- natural transformation from @'NonEmptyF' f@ to @g@.
+runNonEmptyF
+    :: Alt g
+    => (forall x. f x -> g x)
+    -> NonEmptyF f a
+    -> g a
+runNonEmptyF f (NonEmptyF xs) = asum1 (fmap f xs)
+
+-- | A version of 'lift' that can be used with any @f@.
+liftNonEmptyF :: f a -> NonEmptyF f a
+liftNonEmptyF x = NonEmptyF (x :| [])
+
+-- | Given a natural transformation from @f@ to @g@, this gives a canonical
+-- natural transformation from @'NonEmptyF' f@ to @'NonEmptyF' g@.
+hoistNonEmptyF
+    :: (forall a. f a -> g a)
+    -> NonEmptyF f b
+    -> NonEmptyF g b
+hoistNonEmptyF f (NonEmptyF xs) = NonEmptyF (fmap f xs)
+
+-- | Convert a 'NonEmptyF' into a 'ListF', gaining a 'Plus' instance in the
+-- process.
+toListF :: NonEmptyF f a -> ListF f a
+toListF (NonEmptyF xs) = ListF (NE.toList xs)

--- a/src/Data/Functor/Apply/Free.hs
+++ b/src/Data/Functor/Apply/Free.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE DeriveFunctor       #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving  #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeInType          #-}
+{-# LANGUAGE TypeOperators       #-}
+
+module Data.Functor.Apply.Free (
+    Ap1(..)
+  , liftAp1
+  , hoistAp1
+  , runAp1
+  , toAp
+  ) where
+
+import           Control.Applicative.Free
+import           Data.Function
+import           Data.Functor.Apply
+
+-- | The free 'Apply'.  Basically a "non-empty" 'Ap'.
+--
+-- The construction here is based on 'Ap', similar to now
+-- 'Data.List.NonEmpty.NonEmpty' is built on list.
+data Ap1 f a where
+    Ap1 :: f a -> Ap f (a -> b) -> Ap1 f b
+
+deriving instance Functor (Ap1 f)
+
+instance Apply (Ap1 f) where
+    Ap1 x xs <.> ys = Ap1 x (flip <$> xs <*> toAp ys)
+
+-- | A version of 'lift' that can be used with any @f@.
+liftAp1 :: f a -> Ap1 f a
+liftAp1 x = Ap1 x (Pure id)
+
+-- | Given a natural transformation from @f@ to @g@, this gives a canonical
+-- natural transformation from @'Ap1' f@ to @g@.
+runAp1
+    :: Apply g
+    => (forall x. f x -> g x)
+    -> Ap1 f a
+    -> g a
+runAp1 f (Ap1 x xs) = runAp1_ f x xs
+
+-- | Given a natural transformation from @f@ to @g@, this gives a canonical
+-- natural transformation from @'NonEmptyF' f@ to @'NonEmptyF' g@.
+hoistAp1
+    :: (forall x. f x -> g x)
+    -> Ap1 f a
+    -> Ap1 g a
+hoistAp1 f (Ap1 x xs) = Ap1 (f x) (hoistAp f xs)
+
+runAp1_
+    :: forall f g a b. Apply g
+    => (forall x. f x -> g x)
+    -> f a
+    -> Ap f (a -> b)
+    -> g b
+runAp1_ f = go
+  where
+    go :: f x -> Ap f (x -> y) -> g y
+    go x = \case
+      Pure y  ->   y <$> f x
+      Ap y ys -> (&) <$> f x <.> go y ys
+{-# INLINE runAp1_ #-}
+
+-- | Convert an 'Ap1' into an 'Ap', gaining an 'Applicative' instance in
+-- the process.
+toAp :: Ap1 f a -> Ap f a
+toAp (Ap1 x xs) = Ap x xs
+

--- a/src/Data/Functor/Plus/Free.hs
+++ b/src/Data/Functor/Plus/Free.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE DeriveFoldable    #-}
+{-# LANGUAGE DeriveFunctor     #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE RankNTypes        #-}
+
+module Data.Functor.Plus.Free (
+    ListF(..)
+  , runListF
+  , liftListF
+  , hoistListF
+  ) where
+
+import           Data.Functor.Plus
+
+-- | The free 'Plus'
+newtype ListF f a = ListF { plusses :: [f a] }
+  deriving (Functor, Foldable, Traversable)
+
+instance Functor f => Alt (ListF f) where
+    ListF xs <!> ListF ys = ListF (xs <> ys)
+
+instance Functor f => Plus (ListF f) where
+    zero = ListF []
+
+instance Semigroup (ListF f a) where
+    ListF xs <> ListF ys = ListF (xs <> ys)
+
+instance Monoid (ListF f a) where
+    mempty = ListF []
+
+-- | Given a natural transformation from @f@ to @g@, this gives a canonical
+-- natural transformation from @'ListF' f@ to @g@.
+runListF
+    :: Plus g
+    => (forall x. f x -> g x)
+    -> ListF f a
+    -> g a
+runListF f (ListF xs) = foldr ((<!>) . f) zero xs
+
+-- | A version of 'lift' that can be used with any @f@.
+liftListF :: f a -> ListF f a
+liftListF x = ListF [x]
+
+-- | Given a natural transformation from @f@ to @g@, this gives a canonical
+-- natural transformation from @'ListF' f@ to @'ListF' g@.
+hoistListF
+    :: (forall a. f a -> g a)
+    -> ListF f b
+    -> ListF g b
+hoistListF f (ListF xs) = ListF (fmap f xs)


### PR DESCRIPTION
Just added a couple of data types that I've found useful as free structures, that might benefit from being defined in a unified place.

1.  The free `Apply` is constructed based on how `NonEmpty` is constructed in *base*: it just convolves a single `f x` in front of an `Ap`.  It's basically a "non-empty `Ap`"
2. The free `Plus` (which I call `ListF` in this PR) arises from the free monoid of functors combined with `:*:`/`Product`, like how Free Monad is the free monoid against `:.:`/`Compose` and Free Applicative is the free monoid against `Day`.
3. The free `Alt` arises from the free semigroup of functors combined with `:*:`, like how `Apply` is the free semigroup w.r.t. `Day`.

I tried to style the API after the exports in *Control.Alternative.Free* as reference.

Thanks for the great package :)