### PR TITLE
Fix typos

### DIFF
--- a/doc/proof/Control/Comonad/Trans/Cofree/instance-Applicative-CofreeT.md
+++ b/doc/proof/Control/Comonad/Trans/Cofree/instance-Applicative-CofreeT.md
@@ -200,7 +200,7 @@ p               ≡ pure
 .               ≡ (.)
 ```
 
-By repeteadly applying the Applicative laws for the underlying functor, we
+By repeatedly applying the Applicative laws for the underlying functor, we
 get:
 
 ```haskell
@@ -288,7 +288,7 @@ p               ≡ pure
 $W              ≡ ($ star(C w))
 ```
 
-By repeteadly applying composition law for w, we get:
+By repeatedly applying composition law for w, we get:
 
 ```haskell
   

--- a/doc/proof/Control/Comonad/Trans/Cofree/instance-Monad-CofreeT.md
+++ b/doc/proof/Control/Comonad/Trans/Cofree/instance-Monad-CofreeT.md
@@ -20,7 +20,7 @@ instance (Alternative f, Monad w) => Monad (CofreeT f w) where
 This definition is equivalent to that of the Cofree module if 'w' is
 identity. 
 
-The tokens `CofreeT` and `runCofreeT` are abreviated as `C` and `unC`, 
+The tokens `CofreeT` and `runCofreeT` are abbreviated as `C` and `unC`, 
 respectively, for readability.
 
 ## Left identity

--- a/examples/MandelbrotIter.lhs
+++ b/examples/MandelbrotIter.lhs
@@ -1,4 +1,4 @@
-Compiling to an executable file with the @-O2@ optimization level is recomended.
+Compiling to an executable file with the @-O2@ optimization level is recommended.
 
 For example: @ghc -o 'mandelbrot_iter' -O2 MandelbrotIter.lhs ; ./mandelbrot_iter@
 


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos.