### PR TITLE
Put an upper bound on template-haskell dependency

### DIFF
--- a/free.cabal
+++ b/free.cabal
@@ -89,7 +89,7 @@ library
     semigroupoids        >= 4 && < 6,
     transformers         >= 0.2.0   && < 0.6,
     transformers-base    >= 0.4 && < 0.5,
-    template-haskell     >= 2.7.0.0 && < 3,
+    template-haskell     >= 2.7.0.0 && < 2.17,
     exceptions           >= 0.6 && < 0.11,
     containers           < 0.7
 


### PR DESCRIPTION
This is motivated by recent revision to free-5.1.1 and 5.1.2 (which didn't compile with GHC-8.10.1 template-haskell), I suspect free-5.1.3 might break with GHC-8.12 template-haskell. You see the pattern.

EDIT: there is evidence: https://gitlab.haskell.org/ghc/head.hackage/-/blob/master/patches/free-5.1.3.patch