### PR TITLE
Use safer indexed-traversable

### DIFF
--- a/free.cabal
+++ b/free.cabal
@@ -86,7 +86,7 @@ library
     containers           < 0.7,
     distributive         >= 0.2.1,
     exceptions           >= 0.6 && < 0.11,
-    indexed-traversable  >= 0.1 && < 0.2,
+    indexed-traversable  >= 0.1.1 && < 0.2,
     mtl                  >= 2.0.1.0 && < 2.3,
     profunctors          >= 4 && < 6,
     semigroupoids        >= 4 && < 6,


### PR DESCRIPTION
It would be great to make similar revision.

Related to https://github.com/commercialhaskell/stackage/issues