### PR TITLE
Build mandelbrot-iter on CI & use cabal-docspec

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -141,6 +141,15 @@ jobs:
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
+      - name: install cabal-docspec
+        run: |
+          mkdir -p $HOME/.cabal/bin
+          curl -sL https://github.com/phadej/cabal-extras/releases/download/cabal-docspec-0.0.0.20210108/cabal-docspec-0.0.0.20210108.xz > cabal-docspec.xz
+          echo '9123f8d5d09beaf3124331c4db1de3e2934b682cd4deebdcdbd3e71b73016b7c  cabal-docspec.xz' | sha256sum -c -
+          xz -d < cabal-docspec.xz > $HOME/.cabal/bin/cabal-docspec
+          rm -f cabal-docspec.xz
+          chmod a+x $HOME/.cabal/bin/cabal-docspec
+          cabal-docspec --version
       - name: checkout
         uses: actions/checkout@v2
         with:
@@ -190,6 +199,10 @@ jobs:
       - name: build
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
+      - name: docspec
+        run: |
+          $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all
+          cabal-docspec $ARG_COMPILER
       - name: cabal check
         run: |
           cd ${PKGDIR_free} || false

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.11.20201230
+# version: 0.11.20210108
 #
-# REGENDATA ("0.11.20201230",["github","--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.11.20210108",["github","--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -79,7 +79,7 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common
           apt-add-repository -y 'ppa:hvr/ghc'
           apt-get update
-          apt-get install -y ghc-$GHC_VERSION cabal-install-3.2
+          apt-get install -y ghc-$GHC_VERSION cabal-install-3.2 libxrandr-dev libxss-dev
         env:
           GHC_VERSION: ${{ matrix.ghc }}
       - name: Set PATH and environment variables
@@ -169,8 +169,6 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package free-examples" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
-          package free-examples
-            flags: -mandelbrot-iter
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(free|free-examples)$/; }' >> cabal.project.local
           cat cabal.project

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,9 +1,5 @@
+apt:                    libxss-dev libxrandr-dev
 no-tests-no-benchmarks: False
 unconstrained:          False
 irc-channels:           irc.freenode.org#haskell-lens
 irc-if-in-origin-repo:  True
-
-raw-project
-  package free-examples
-     -- Can't build HGL on Travis
-     flags: -mandelbrot-iter

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -3,3 +3,4 @@ no-tests-no-benchmarks: False
 unconstrained:          False
 irc-channels:           irc.freenode.org#haskell-lens
 irc-if-in-origin-repo:  True
+docspec:                True

--- a/examples/free-examples.cabal
+++ b/examples/free-examples.cabal
@@ -43,9 +43,6 @@ library
     mtl          >= 2.0.1 && < 2.3,
     transformers >= 0.2   && < 0.6
 
--- This example depends on the HGL library which, unfortunately, fails to
--- compile on GHC 8.4 or later. (See https://github.com/xpika/hgl/issues/3.)
--- Build at your own risk.
 executable free-mandelbrot-iter
   if !flag(mandelbrot-iter)
     buildable: False
@@ -56,7 +53,7 @@ executable free-mandelbrot-iter
   build-depends:
     base == 4.*,
     free,
-    HGL,
+    HGL          >= 3.2.3.2,
     mtl          >= 2.0.1 && < 2.3,
     transformers >= 0.2   && < 0.6
 

--- a/free.cabal
+++ b/free.cabal
@@ -160,3 +160,5 @@ library
     -- these flags may abort compilation with GHC-8.10
     -- https://gitlab.haskell.org/ghc/ghc/-/merge_requests/3295
     ghc-options: -Winferred-safe-imports -Wmissing-safe-haskell-mode
+
+  x-docspec-extra-packages: tagged

--- a/src/Control/Monad/Free.hs
+++ b/src/Control/Monad/Free.hs
@@ -71,6 +71,14 @@ import Prelude hiding (foldr)
 import GHC.Generics
 #endif
 
+-- $setup
+-- >>> import Control.Applicative (Const (..))
+-- >>> import Data.Functor.Identity (Identity (..))
+-- >>> import Data.Monoid (First (..))
+-- >>> import Data.Tagged (Tagged (..))
+-- >>> let preview l x = getFirst (getConst (l (Const . First . Just) x))
+-- >>> let review l x = runIdentity (unTagged (l (Tagged (Identity x))))
+
 -- | The 'Free' 'Monad' for a 'Functor' @f@.
 --
 -- /Formally/

--- a/src/Control/Monad/Free/Ap.hs
+++ b/src/Control/Monad/Free/Ap.hs
@@ -77,6 +77,14 @@ import Prelude hiding (foldr)
 import GHC.Generics
 #endif
 
+-- $setup
+-- >>> import Control.Applicative (Const (..))
+-- >>> import Data.Functor.Identity (Identity (..))
+-- >>> import Data.Monoid (First (..))
+-- >>> import Data.Tagged (Tagged (..))
+-- >>> let preview l x = getFirst (getConst (l (Const . First . Just) x))
+-- >>> let review l x = runIdentity (unTagged (l (Tagged (Identity x))))
+
 -- | A free monad given an applicative
 data Free f a = Pure a | Free (f (Free f a))
 #if __GLASGOW_HASKELL__ >= 707


### PR DESCRIPTION
There are plenty of `prop>` in `free`, but most of them aren't "decidable", e.g.

```haskell
src/Control/Monad/Free/Church.hs:--   prop> fmap f . fmap g == fmap (f . g)
src/Control/Monad/Trans/Iter.hs:-- prop> runIter . iter == id
```

(or/and would require quite a large setup to ctually run, `QuickCheck` instances etc.).

---

With this PR I'm able to run `cabal-docspec` on a single kmettverse project at once. That is quite cool.