### PR TITLE
Simplify the `Eq`/`Ord` instances for `FT`

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,8 @@
+next [????.??.??]
+-----------------
+* Simplify the `Eq` and `Ord` instances for `FT` to avoid the use of
+  overlapping instances.
+
 5.1.8 [2022.05.07]
 ------------------
 * Generalize the `Monad` constraint in the type signatures for

--- a/src/Control/Monad/Trans/Free/Church.hs
+++ b/src/Control/Monad/Trans/Free/Church.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
@@ -97,10 +96,20 @@ instance ( Functor f, Monad m, Ord1 f, Ord1 m
   compare1 x y = compare1 (fromFT x) (fromFT y)
 #endif
 
-instance (Eq1 (FT f m), Eq a) => Eq (FT f m a) where
+instance ( Functor f, Monad m, Eq1 f, Eq1 m
+# if !(MIN_VERSION_base(4,8,0))
+         , Functor m
+# endif
+         , Eq a
+         ) => Eq (FT f m a) where
   (==) = eq1
 
-instance (Ord1 (FT f m), Ord a) => Ord (FT f m a) where
+instance ( Functor f, Monad m, Ord1 f, Ord1 m
+# if !(MIN_VERSION_base(4,8,0))
+         , Functor m
+# endif
+         , Ord a
+         ) => Ord (FT f m a) where
   compare = compare1
 
 instance Functor (FT f m) where


### PR DESCRIPTION
While slightly more verbose, the new instance contexts avoid the need for overlapping instances or `FlexibleContexts`.

This should also allow `free` to compile with the changes in haskell/core-libraries-committee#10. cc @Bodigrim