### PR TITLE
Add Eq(1) and Ord(1) instances for the free applicative

### DIFF
--- a/src/Control/Applicative/Free.hs
+++ b/src/Control/Applicative/Free.hs
@@ -134,15 +134,15 @@ Haddock markup. It is to allow rendering them to ease reading this rather long d
 
 === About the definition of @Eq1 (Ap f)@ instance
 
-The @Eq1 (Ap f)@ instance below have a complex definition. This comment
+The @Eq1 (Ap f)@ instance below has a complex definition. This comment
 explains why it is defined like that.
 
 The discussion given here also applies to @Ord1 (Ap f)@ instance with a little change.
 
 ==== General discussion about @Eq1@ type class
 
-Currently, there isn't a law on @Eq1@ type class, but the following
-property can be expected.
+Currently, there isn't a law on the @Eq1@ type class, but the following
+properties can be expected.
 
 * If @Eq (f ())@, and @Functor f@ holds, @Eq1 f@ satisfies
 
@@ -159,7 +159,8 @@ Let's define the commonly used function @liftEq (\\_ _ -> True)@ as @boringEq@.
 > boringEq :: Eq1 f => f a -> f b -> Bool
 > boringEq = liftEq (\_ _ -> True)
 
-Changing constant @True@ to constant @False@ in the @boringEq@, let @emptyEq@ function be defined.
+Changing the constant @True@ to the constant @False@ in the definition of
+@boringEq@, let @emptyEq@ function be defined as:
 
 > emptyEq :: Eq1 f => f a -> f b -> Bool
 > emptyEq = liftEq (\_ _ -> False)
@@ -170,12 +171,12 @@ From the above properties expectated on a @Eq1@ instance, @emptyEq@ satisfies th
 
 ==== About @instance (Eq1 (Ap f))@
 
-If we're to define @Eq1 (Ap f)@ satisfying these properties expected, @Eq (Ap f ())@ will determine
+If we're to define @Eq1 (Ap f)@ satisfying these properties as expected, @Eq (Ap f ())@ will determine
 how @liftEq@ should behave. It's not unreasonable to define equality between @Ap f ()@ as below.
 
 > boringEqAp (Pure _) (Pure _) = True
 > boringEqAp (Ap x1 y1) (Ap x2 y2) = boringEq x1 x2 && boringEqAp y1 y2
->    {-  = ((() <$ x1) == (() <$ x2)) && (y1 == y2)  -} 
+>    {-  = ((() <$ x1) == (() <$ x2)) && (y1 == y2)  -}
 > boringEqAp _ _ = False
 
 Its type can be more general than equality between @Ap f ()@:
@@ -211,7 +212,7 @@ If @zip as1 as2@ is /not/ empty, the following transformation is valid.
 >   = boringEq x1 x2 && all (\(a1, a2) -> liftEq (\g1 g2 -> eq (g1 a1) (g2 a2)) y1 y2) (zip as1 as2)
 >   = liftEq (\a1 a2 -> liftEq (\g1 g2 -> eq (g1 a1) (g2 a2)) y1 y2)) x1 x2
 
-Because, generally, the following transformation is valid if @xs@ is nonempty list.
+Because, generally, the following transformation is valid if @xs@ is a nonempty list.
 
 > cond && all p xs = all (\x -> cond && p x) xs -- Only when xs is not empty!
 
@@ -255,7 +256,7 @@ liftEqAp :: (Eq1 f, Functor f) => (a -> b -> Bool) -> Ap f a -> Ap f b -> Bool
 #endif
 liftEqAp eq (Pure a1) (Pure a2) = eq a1 a2
 liftEqAp eq (Ap x1 y1) (Ap x2 y2)
-    -- This branching is not an optimization and necessary.
+    -- This branching is necessary and not just an optimization.
     -- See the above comment for more
   | emptyEq x1 x2 = boringEqAp y1 y2
   | otherwise =
@@ -297,7 +298,7 @@ liftCompareAp :: (Ord1 f, Functor f) => (a -> b -> Ordering) -> Ap f a -> Ap f b
 liftCompareAp cmp (Pure a1) (Pure a2) = cmp a1 a2
 liftCompareAp _   (Pure _) (Ap _ _) = LT
 liftCompareAp cmp (Ap x1 y1) (Ap x2 y2)
-    -- This branching is not an optimization and necessary.
+    -- This branching is necessary and not just an optimization.
     -- See the above comment for more
   | emptyEq x1 x2 = boringCompareAp y1 y2
   | otherwise     = liftCompare (\a1 a2 -> liftCompareAp (\g1 g2 -> cmp (g1 a1) (g2 a2)) y1 y2) x1 x2

--- a/src/Control/Applicative/Free.hs
+++ b/src/Control/Applicative/Free.hs
@@ -101,7 +101,7 @@ instance Comonad f => Comonad (Ap f) where
 #ifdef LIFTED_FUNCTOR_CLASSES
 boringEqAp :: Eq1 f => Ap f a -> Ap f b -> Bool
 #else
-boringEqAp :: (Eq1 f, Functor f, Foldable f) => Ap f a -> Ap f b -> Bool
+boringEqAp :: (Eq1 f, Functor f) => Ap f a -> Ap f b -> Bool
 #endif
 boringEqAp (Pure _) (Pure _) = True
 boringEqAp (Ap x1 y1) (Ap x2 y2) = boringEq x1 x2 && boringEqAp y1 y2
@@ -160,7 +160,7 @@ liftCompareAp _   (Ap _ _) (Pure _) = GT
 instance Ord1 f => Ord1 (Ap f) where
   liftCompare = liftCompareAp
 #else
-instance Ord1 f => Ord1 (Ap f) where
+instance (Ord1 f, Functor f) => Ord1 (Ap f) where
   compare1 = liftCompareAp compare
 #endif
 

--- a/src/Control/Applicative/Free.hs
+++ b/src/Control/Applicative/Free.hs
@@ -98,6 +98,117 @@ instance Comonad f => Comonad (Ap f) where
   duplicate (Pure a) = Pure (Pure a)
   duplicate (Ap x y) = Ap (duplicate x) (extend (flip Ap) y)
 
+{- $note_eq1
+
+This comment section is an internal documentation, but written in proper
+Haddock markup. It is to allow rendering them to ease reading this rather long document.
+
+=== About the definition of @Eq1 (Ap f)@ instance
+
+The @Eq1 (Ap f)@ instance below have a complex definition. This comment
+explains why it is defined like that.
+
+The discussion given here also applies to @Ord1 (Ap f)@ instance with a little change.
+
+==== General discussion about @Eq1@ type class
+
+Currently, there isn't a law on @Eq1@ type class, but the following
+property can be expected.
+
+* If @Eq (f ())@, and @Functor f@ holds, @Eq1 f@ satisfies
+
+    > liftEq (\_ _ -> True) x y == (() <$ x) == (() <$ y)
+
+* If @Foldable f@ holds, @Eq1 f@ satisfies:
+
+    * @boringEq x y@ implies @length (toList x) == length (toList y)@
+
+    * @liftEq eq x y == liftEq (\_ _ -> True) && all (\(a,b) -> eq a b)) (zip (toList x) (toList y))@
+
+Let's define the commonly used function @liftEq (\\_ _ -> True)@ as @boringEq@.
+
+> boringEq :: Eq1 f => f a -> f b -> Bool
+> boringEq = liftEq (\_ _ -> True)
+
+Changing constant @True@ to constant @False@ in the @boringEq@, let @emptyEq@ function be defined.
+
+> emptyEq :: Eq1 f => f a -> f b -> Bool
+> emptyEq = liftEq (\_ _ -> False)
+
+From the above properties expectated on a @Eq1@ instance, @emptyEq@ satisfies the following.
+
+> emptyEq x y = boringEq x y && null (zip (toList x) (toList y))
+
+==== About @instance (Eq1 (Ap f))@
+
+If we're to define @Eq1 (Ap f)@ satisfying these properties expected, @Eq (Ap f ())@ will determine
+how @liftEq@ should behave. It's not unreasonable to define equality between @Ap f ()@ as below.
+
+> boringEqAp (Pure _) (Pure _) = True
+> boringEqAp (Ap x1 y1) (Ap x2 y2) = boringEq x1 x2 && boringEqAp y1 y2
+>    {-  = ((() <$ x1) == (() <$ x2)) && (y1 == y2)  -} 
+> boringEqAp _ _ = False
+
+Its type can be more general than equality between @Ap f ()@:
+
+> boringEqAp :: Eq1 f => Ap f a -> Ap f b -> Bool
+
+Using @boringEqAp@, the specification of @liftEq@ will be:
+
+> liftEq eq x y = boringEqAp x y && and (zipWith eq (toList x) (toList y))
+
+Then unfold @toList@ to remove the dependency to @Foldable@.
+
+> liftEq eq (Pure a1) (Pure a2)
+>   = boringEqAp (Pure a1) (Pure a2) && all (\(a,b) -> eq a b)) (zip (toList (Pure x)) (toList Pure y))
+>   = True && all (\(a,b) -> eq a b) (zip [a1] [a2])
+>   = eq a1 a2
+> liftEq eq (Ap x1 y1) (Ap x2 y2)
+>   = boringEqAp (Ap x1 y1) (Ap x2 y2) && all (\(b1, b2) -> eq b1 b2) (zip (toList (Ap x1 y1)) (toList (Ap x2 y2)))
+>   = boringEq x1 y1 && boringEqAp y1 y2 && all (\(b1, b2) -> eq b1 b2) (zip (toList x1 <**> toList y1) (toList x2 <**> toList y2))
+>   = boringEq x1 y1 && boringEqAp y1 y2 && all (\(b1, b2) -> eq b1 b2) (zip (as1 <**> gs1) (as2 <**> gs2))
+>        where as1 = toList x1
+>              as2 = toList x2
+>              gs1 = toList y1
+>              gs2 = toList y2
+>   = boringEq x1 y1 && boringEqAp y1 y2 && all (\(a1, a2) -> all (\(g1, g2) -> eq (g1 a1) (g2 a2)) (zip gs1 gs2)) (zip as1 as2)
+
+If @zip as1 as2@ is /not/ empty, the following transformation is valid.
+
+> (...) | not (null (zip as1 as2))
+>   = boringEq x1 x2 && boringEqAp y1 y2 && all (\(a1, a2) -> all (\(g1, g2) -> eq (g1 a1) (g2 a2)) (zip gs1 gs2)) (zip as1 as2)
+>   = boringEq x1 x2 && all (\(a1, a2) -> boringEqAp y1 y2 && all (\(g1, g2) -> eq (g1 a1) (g2 a2)) (zip gs1 gs2)) (zip as1 as2)
+> --                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>   = boringEq x1 x2 && all (\(a1, a2) -> liftEq (\g1 g2 -> eq (g1 a1) (g2 a2)) y1 y2) (zip as1 as2)
+>   = liftEq (\a1 a2 -> liftEq (\g1 g2 -> eq (g1 a1) (g2 a2)) y1 y2)) x1 x2
+
+Because, generally, the following transformation is valid if @xs@ is nonempty list.
+
+> cond && all p xs = all (\x -> cond && p x) xs -- Only when xs is not empty!
+
+If @zip as1 as2@ is empty, @all (...) (zip as1 as2)@ is vacuously true, so the following transformation is valid.
+
+> (...) | null (zip as1 as2)
+>   = boringEq x1 x2 && boringEqAp y1 y2 && all (\(a1, a2) -> all (\(g1, g2) -> eq (g1 a1) (g2 a2)) (zip gs1 gs2)) (zip as1 as2)
+>   = boringEq x1 x2 && boringEqAp y1 y2
+
+Combining two cases:
+
+> liftEq eq (Ap x1 y1) (Ap x2 y2)
+>   = null (zip as1 as2) && boringEq x1 x2 && boringEqAp y1 y2
+>       || not (null (zip as1 as2)) && liftEq (\a1 a2 -> liftEq (\g1 g2 -> eq (g1 a1) (g2 a2)) y1 y2)) x1 x2
+>   = null (zip as1 as2) && boringEq x1 x2 && boringEqAp y1 y2
+>       || liftEq (\a1 a2 -> liftEq (\g1 g2 -> eq (g1 a1) (g2 a2)) y1 y2)) x1 x2
+>   = emptyEq x1 x2 && boringEqAp y1 y2
+>       || liftEq (\a1 a2 -> liftEq (\g1 g2 -> eq (g1 a1) (g2 a2)) y1 y2)) x1 x2
+
+The property about @emptyEq@ is used in the last equation.
+
+Hence it's defined as this source code.
+
+-}
+
+-- | Specialized 'boringEq' for @Ap f@.
 #ifdef LIFTED_FUNCTOR_CLASSES
 boringEqAp :: Eq1 f => Ap f a -> Ap f b -> Bool
 #else
@@ -107,6 +218,7 @@ boringEqAp (Pure _) (Pure _) = True
 boringEqAp (Ap x1 y1) (Ap x2 y2) = boringEq x1 x2 && boringEqAp y1 y2
 boringEqAp _ _ = False
 
+-- | Implementaion of 'liftEq' for @Ap f@.
 #ifdef LIFTED_FUNCTOR_CLASSES
 liftEqAp :: Eq1 f => (a -> b -> Bool) -> Ap f a -> Ap f b -> Bool
 #else
@@ -114,6 +226,8 @@ liftEqAp :: (Eq1 f, Functor f) => (a -> b -> Bool) -> Ap f a -> Ap f b -> Bool
 #endif
 liftEqAp eq (Pure a1) (Pure a2) = eq a1 a2
 liftEqAp eq (Ap x1 y1) (Ap x2 y2)
+    -- This branching is not an optimization and necessary.
+    -- See the above comment for more
   | emptyEq x1 x2 = boringEqAp y1 y2
   | otherwise =
       liftEq (\a1 a2 -> liftEqAp (\g1 g2 -> eq (g1 a1) (g2 a2)) y1 y2) x1 x2
@@ -134,6 +248,7 @@ instance (Eq1 f, Functor f, Eq a) => Eq (Ap f a) where
 #endif
   (==) = eq1
 
+-- | Specialized 'boringCompare' for @Ap f@.
 #ifdef LIFTED_FUNCTOR_CLASSES
 boringCompareAp :: Ord1 f => Ap f a -> Ap f b -> Ordering
 #else
@@ -144,6 +259,7 @@ boringCompareAp (Pure _) (Ap _ _) = LT
 boringCompareAp (Ap x1 y1) (Ap x2 y2) = boringCompare x1 x2 `mappend` boringCompareAp y1 y2
 boringCompareAp (Ap _ _) (Pure _) = GT
 
+-- | Implementation of 'liftCompare' for @Ap f@
 #ifdef LIFTED_FUNCTOR_CLASSES
 liftCompareAp :: Ord1 f => (a -> b -> Ordering) -> Ap f a -> Ap f b -> Ordering
 #else
@@ -152,6 +268,8 @@ liftCompareAp :: (Ord1 f, Functor f) => (a -> b -> Ordering) -> Ap f a -> Ap f b
 liftCompareAp cmp (Pure a1) (Pure a2) = cmp a1 a2
 liftCompareAp _   (Pure _) (Ap _ _) = LT
 liftCompareAp cmp (Ap x1 y1) (Ap x2 y2)
+    -- This branching is not an optimization and necessary.
+    -- See the above comment for more
   | emptyEq x1 x2 = boringCompareAp y1 y2
   | otherwise     = liftCompare (\a1 a2 -> liftCompareAp (\g1 g2 -> cmp (g1 a1) (g2 a2)) y1 y2) x1 x2
 liftCompareAp _   (Ap _ _) (Pure _) = GT

--- a/src/Data/Functor/Classes/Compat.hs
+++ b/src/Data/Functor/Classes/Compat.hs
@@ -3,6 +3,9 @@
 {-# LANGUAGE Safe #-}
 module Data.Functor.Classes.Compat (
     mappend,
+    boringEq,
+    emptyEq,
+    boringCompare,
     module Data.Functor.Classes,
     ) where
 
@@ -11,6 +14,15 @@ import Data.Functor.Classes
 #if !(MIN_VERSION_base(4,8,0))
 import Data.Monoid (mappend)
 #endif
+
+boringEq :: Eq1 f => f a -> f b -> Bool
+boringEq = liftEq (\_ _ -> True)
+
+emptyEq :: Eq1 f => f a -> f b -> Bool
+emptyEq = liftEq (\_ _ -> False)
+
+boringCompare :: Ord1 f => f a -> f b -> Ordering
+boringCompare = liftCompare (\_ _ -> EQ)
 #else
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -18,6 +30,11 @@ import Data.Monoid (mappend)
 module Data.Functor.Classes.Compat (
     Lift1 (..),
     on,
+    boringEq,
+    emptyEq,
+    liftEq,
+    boringCompare,
+    liftCompare,
     module Data.Functor.Classes,
     ) where
 
@@ -42,4 +59,48 @@ instance (Eq1 f, Eq a) => Eq (Lift1 f a)       where (==) = eq1
 instance (Ord1 f, Ord a) => Ord (Lift1 f a)    where compare = compare1
 instance (Show1 f, Show a) => Show (Lift1 f a) where showsPrec = showsPrec1
 instance (Read1 f, Read a) => Read (Lift1 f a) where readsPrec = readsPrec1
+
+boringEq :: (Eq1 f, Functor f) => f a -> f b -> Bool
+boringEq fa fb = eq1 (() <$ fa) (() <$ fb)
+
+-- | Internal only, do not export
+data AlwaysFalse = AlwaysFalse
+
+instance Eq AlwaysFalse where
+  _ == _ = False
+
+emptyEq :: (Eq1 f, Functor f) => f a -> f b -> Bool
+emptyEq fa fb = eq1 (AlwaysFalse <$ fa) (AlwaysFalse <$ fb)
+
+-- | Internal only, do not export
+data EqualityTmp b = EqualityLeft (b -> Bool) | EqualityRight b
+
+instance Eq (EqualityTmp b) where
+  EqualityLeft f == EqualityRight x = f x
+  EqualityRight x == EqualityLeft f = f x
+  _ == _ = error "Undefined combination for equality"
+
+-- | Emulated @liftEq@ using old @eq1@
+liftEq :: (Eq1 f, Functor f) => (a -> b -> Bool) -> f a -> f b -> Bool
+liftEq eq fa fb = eq1 (fmap (EqualityLeft . eq) fa) (fmap EqualityRight fb)
+
+boringCompare :: (Ord1 f, Functor f) => f a -> f b -> Ordering
+boringCompare fa fb = compare1 (() <$ fa) (() <$ fb)
+
+-- | Internal only, do not export
+data ComparisonTmp b = ComparisonLeft (b -> Ordering) | ComparisonRight b
+
+instance Eq (CompareTmp b) where
+  x == y = compare x y == EQ
+instance Ord (CompareTmp b) where
+  compare (ComparisonLeft f) (ComparisonRight b) = f b
+  compare (ComparisonRight b) (ComparisonLeft f) = case f b of
+    LT -> GT
+    EQ -> EQ
+    GT -> LT
+  compare _ _ = error "Unexpected combination for comparison"
+
+-- | Emulated @liftCompare@ using old @compare1@
+liftCompare :: (Ord1 f, Functor f) => (a -> b -> Ordering) -> f a -> f b -> Ordering
+liftCompare cmp fa fb = compare1 (fmap (ComparisonLeft . cmp) fa) (fmap ComparisonRight fb)
 #endif

--- a/src/Data/Functor/Classes/Compat.hs
+++ b/src/Data/Functor/Classes/Compat.hs
@@ -17,7 +17,7 @@ import Data.Monoid (mappend)
 
 -- | @boringEq fa fb@ tests if @fa@ and @fb@ are equal ignoring any difference between
 --   their content (the values of their last parameters @a@ and @b@.)
---   
+--
 --   It is named \'boring\' because the type parameters @a@ and @b@ are
 --   treated as if they are the most boring type @()@.
 boringEq :: Eq1 f => f a -> f b -> Bool
@@ -32,9 +32,9 @@ boringEq = liftEq (\_ _ -> True)
 --   If @f@ is also @Foldable@, @emptyEq fa fb@ would be equivalent to
 --   @null fa && null fb && liftEq eq@ for any @eq :: a -> b -> Bool@.
 --
---   (It depends on each instances of @Eq1@. Since @Eq1@ does not have
---   any laws now, this is not a hard guarantee. But all instances in "base", "transformers",
---   "containers", "array", and "free" satisfies it.)
+--   (It depends on each instance of @Eq1@. Since @Eq1@ does not have
+--   any laws currently, this is not a hard guarantee. But all instances in "base", "transformers",
+--   "containers", "array", and "free" satisfy it.)
 --
 --   Note that @emptyEq@ is not a equivalence relation, since it's possible @emptyEq x x == False@.
 emptyEq :: Eq1 f => f a -> f b -> Bool

--- a/src/Data/Functor/Classes/Compat.hs
+++ b/src/Data/Functor/Classes/Compat.hs
@@ -90,9 +90,9 @@ boringCompare fa fb = compare1 (() <$ fa) (() <$ fb)
 -- | Internal only, do not export
 data ComparisonTmp b = ComparisonLeft (b -> Ordering) | ComparisonRight b
 
-instance Eq (CompareTmp b) where
+instance Eq (ComparisonTmp b) where
   x == y = compare x y == EQ
-instance Ord (CompareTmp b) where
+instance Ord (ComparisonTmp b) where
   compare (ComparisonLeft f) (ComparisonRight b) = f b
   compare (ComparisonRight b) (ComparisonLeft f) = case f b of
     LT -> GT


### PR DESCRIPTION
This adds instances of `Eq, Ord, Eq1, Ord1` instances to `Control.Applicative.Free.Ap`. Might want to look out for:

* Instance for the older `Eq1` class, defined in terms of `eq1 :: Eq a => f a -> f a -> Bool`, is hacky.

* It adds some utility functions to `Data.Functor.Classes.Compat`. If this is an undesirable place to add these functions, I'll move them somewhere.