### PR TITLE
Add nix shell with x11 libraries

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,5 @@
+{ pkgs ? import <nixpkgs> {} }:
+let X11-deps = with pkgs.xorg; [ libX11 libXrandr libXScrnSaver libXext ]; # needed for building mandelbrot example
+in pkgs.mkShell {
+  buildInputs = X11-deps;
+}


### PR DESCRIPTION
Took me a bit to figure out the x11 libraries needed to get the X11 package to build. 
Should be useful for NixOS users at least.